### PR TITLE
Implement Sankey Diagram

### DIFF
--- a/client_code/Main/FiguresPanel/__init__.py
+++ b/client_code/Main/FiguresPanel/__init__.py
@@ -58,9 +58,11 @@ class FiguresPanel(FiguresPanelTemplate):
         try:
             self._plot(layout[tab.tag][sub_tab.tag]["Top"])
             self._plot(layout[tab.tag][sub_tab.tag]["Bottom"])
-            self._plot(layout[tab.tag][sub_tab.tag]["Page"])
         except KeyError:
-            pass
+            try:
+                self._plot(layout[tab.tag][sub_tab.tag]["Page"])
+            except KeyError:
+                pass
 
     def _plot(self, graph_data):
         plot = Plot()

--- a/client_code/Plots.py
+++ b/client_code/Plots.py
@@ -16,6 +16,7 @@ def plot_stacked_area(x, model_output):
     return [
         _partial_scatter(x, y, name=name, mode="lines", stackgroup="one")
         for name, y in _prepare_rows(model_output, x)
+        if "total" not in name.lower()
     ]
 
 
@@ -23,10 +24,37 @@ def plot_line(x, model_output):
     return [
         _partial_scatter(x, y, name, mode="lines+markers")
         for name, y in _prepare_rows(model_output, x)
+        if "total" not in name.lower()
+    ]
+
+
+def plot_sankey(x, model_output):
+    sources = []
+    targets = []
+    values = []
+    for row in model_output[1::]:
+        sources.append(row[0])
+        targets.append(row[1])
+        values.append(sum(row[2 : len(x) + 2]))
+
+    nodes = list(set(sources + targets))
+    sources = [nodes.index(source) for source in sources]
+    targets = [nodes.index(target) for target in targets]
+
+    return [
+        go.Sankey(
+            valueformat=".0f",
+            valuesuffix="TWh",  # Get from Model2050Server.TABLE["Axis Unit"] ?
+            node=dict(
+                pad=15, thickness=15, line=dict(color="black", width=0.5), label=nodes,
+            ),
+            link=dict(source=sources, target=targets, value=values,),
+        )
     ]
 
 
 PLOTS_REGISTRY = {
     "stacked area with overlying line(s)": plot_stacked_area,
     "line": plot_line,
+    "sankey/flow": plot_sankey,
 }


### PR DESCRIPTION
Creates the plot type for the Sankey Diagram.

Also includes a very simple table option that was requested but isn't used by any of the outputs in the Mackay calculator (is also useful for debugging).

Removes the "Total" traces from the line plots.