### PR TITLE
Include app_config.yaml in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,4 @@
 !requirements.txt
 !.anvil_editor.yaml
 !web_outputs.json
-!app_config.yaml
+!app_config.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 !requirements.txt
 !.anvil_editor.yaml
 !web_outputs.json
+!app_config.yaml


### PR DESCRIPTION
Error on the [Azure website](https://calc2050template.azurewebsites.net) because app_config could not be found:
AnvilWrappedError: [Errno 2] No such file or directory: '/apps/Template2050Calculator/app_config.yml'

I think this is all that's required to fix it.